### PR TITLE
Fix request signing, add autohide to toolbar

### DIFF
--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/api/ApiSignInterceptor.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/api/ApiSignInterceptor.kt
@@ -30,8 +30,8 @@ class ApiSignInterceptor(val userManagerApi: UserManagerApi) : Interceptor {
                 val formBody = request.body() as FormBody
                 val paramList = (0 until formBody.size())
                         .filter { !formBody.value(it).isNullOrEmpty() }
+                        .sortedWith(compareBy({ formBody.name(it) }))
                         .mapTo(ArrayList<String>()) { formBody.value(it) }
-                paramList.sort()
 
                 APP_SECRET + url+ paramList.joinToString(",")
             }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/base/BaseNavigationFragment.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/base/BaseNavigationFragment.kt
@@ -1,7 +1,9 @@
 package io.github.feelfreelinux.wykopmobilny.base
 
+import android.view.View
 import io.github.feelfreelinux.wykopmobilny.ui.modules.mainnavigation.MainNavigationInterface
 
 abstract class BaseNavigationFragment : BaseFragment() {
     val navigation by lazy { activity as MainNavigationInterface }
+    var fab : View? = null
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mainnavigation/MainNavigationActivity.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mainnavigation/MainNavigationActivity.kt
@@ -14,6 +14,7 @@ import com.evernote.android.job.util.JobUtil
 import io.github.feelfreelinux.wykopmobilny.R
 import io.github.feelfreelinux.wykopmobilny.WykopApp
 import io.github.feelfreelinux.wykopmobilny.base.BaseActivity
+import io.github.feelfreelinux.wykopmobilny.base.BaseNavigationFragment
 import io.github.feelfreelinux.wykopmobilny.ui.dialogs.AppExitConfirmationDialog
 import io.github.feelfreelinux.wykopmobilny.ui.modules.loginscreen.LoginScreenActivity
 import io.github.feelfreelinux.wykopmobilny.ui.modules.loginscreen.USER_LOGGED_IN
@@ -145,6 +146,11 @@ class NavigationActivity : BaseActivity(), MainNavigationView, NavigationView.On
 
 
     override fun openFragment(fragment: Fragment) {
+        fab.isVisible = false
+        fab.setOnClickListener(null)
+
+        if (fragment is BaseNavigationFragment) fragment.fab = fab
+
         supportFragmentManager.beginTransaction().replace(R.id.contentView,
                 fragment).addToBackStack(fragment.tag).commit()
     }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/feed/BaseFeedList.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/feed/BaseFeedList.kt
@@ -30,6 +30,7 @@ class BaseFeedList : CoordinatorLayout, SwipeRefreshLayout.OnRefreshListener, Ba
     var presenter : BaseFeedPresenter? = null
     var onFabClickedListener = {}
     var shouldShowFab = true
+    var fab : View? = null
 
     private val feedAdapter by lazy { FeedAdapter() }
 
@@ -43,8 +44,8 @@ class BaseFeedList : CoordinatorLayout, SwipeRefreshLayout.OnRefreshListener, Ba
 
     fun initAdapter(feedList: List<Entry>? = emptyList()) {
         // Add endlessScrolListener, and FabAutohide to recyclerview
-        fab.isVisible = false // We'll show it later.
-        fab.setOnClickListener { onFabClickedListener.invoke() }
+        fab?.isVisible = false // We'll show it later.
+        fab?.setOnClickListener { onFabClickedListener.invoke() }
 
         recyclerView.apply {
             adapter = feedAdapter
@@ -74,7 +75,7 @@ class BaseFeedList : CoordinatorLayout, SwipeRefreshLayout.OnRefreshListener, Ba
             recyclerView.post {
                 feedAdapter.addData(entryList, shouldClearAdapter)
 
-                if (feedAdapter.data.size == entryList.size) fab.isVisible = shouldShowFab // First time add only.
+                if (feedAdapter.data.size == entryList.size) fab?.isVisible = shouldShowFab // First time add only.
                 if (shouldClearAdapter) recyclerView.smoothScrollToPosition(0)
             }
         }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/feed/hot/HotFragment.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/feed/hot/HotFragment.kt
@@ -33,6 +33,7 @@ class HotFragment : BaseNavigationFragment(), HotView {
         view?.feedRecyclerView.apply {
             feedRecyclerView = this@apply!!
             this.presenter = this@HotFragment.presenter
+            fab = this@HotFragment.fab
             onFabClickedListener = {
                 this@HotFragment.context.createNewEntry(null)
             }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/feed/tag/TagActivity.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/feed/tag/TagActivity.kt
@@ -55,6 +55,7 @@ class TagActivity : BaseActivity(), TagView {
             presenter = this@TagActivity.presenter
             initAdapter(tagDataFragment.data?.model)
 
+            fab = this@TagActivity.fab
             onFabClickedListener = {
                 context.createNewEntry(null)
             }

--- a/app/src/main/res/layout/activity_entry.xml
+++ b/app/src/main/res/layout/activity_entry.xml
@@ -4,23 +4,38 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <include layout="@layout/toolbar"/>
 
-    <android.support.v4.widget.SwipeRefreshLayout
-        android:id="@+id/swiperefresh"
+    <android.support.design.widget.CoordinatorLayout
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@id/inputToolbar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar">
+        app:layout_constraintTop_toTopOf="parent">
 
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/recyclerView"
+        <android.support.design.widget.AppBarLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="visible" />
-    </android.support.v4.widget.SwipeRefreshLayout>
+            android:layout_height="wrap_content">
+            <include
+                layout="@layout/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|enterAlways" />
+        </android.support.design.widget.AppBarLayout>
+
+        <android.support.v4.widget.SwipeRefreshLayout
+            android:id="@+id/swiperefresh"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/recyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:visibility="visible" />
+        </android.support.v4.widget.SwipeRefreshLayout>
+    </android.support.design.widget.CoordinatorLayout>
 
     <ProgressBar
         android:id="@+id/loadingView"
@@ -32,7 +47,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <io.github.feelfreelinux.wykopmobilny.ui.widgets.InputToolbar
         android:id="@+id/inputToolbar"

--- a/app/src/main/res/layout/activity_feed.xml
+++ b/app/src/main/res/layout/activity_feed.xml
@@ -1,10 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <include layout="@layout/toolbar"/>
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <include
+            layout="@layout/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_scrollFlags="scroll|enterAlways" />
+    </android.support.design.widget.AppBarLayout>
+
     <io.github.feelfreelinux.wykopmobilny.ui.modules.mikroblog.feed.BaseFeedList
         android:id="@+id/feedRecyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</LinearLayout>
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:src="@drawable/ic_pen"
+        app:elevation="5dp"
+        app:fabSize="normal"
+        app:layout_anchor="@id/feedRecyclerView"
+        app:layout_anchorGravity="bottom|right" />
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_navigation.xml
+++ b/app/src/main/res/layout/activity_navigation.xml
@@ -5,21 +5,40 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
+    <android.support.design.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-        <include
-            layout="@layout/toolbar"
+        <android.support.design.widget.AppBarLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content">
+            <include
+                layout="@layout/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|enterAlways" />
+        </android.support.design.widget.AppBarLayout>
+
         <FrameLayout
             android:id="@+id/contentView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical"/>
-    </LinearLayout>
+            android:orientation="vertical"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/fab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="16dp"
+            android:src="@drawable/ic_pen"
+            app:elevation="5dp"
+            app:fabSize="normal"
+            app:layout_anchor="@id/contentView"
+            app:layout_anchorGravity="bottom|right" />
+    </android.support.design.widget.CoordinatorLayout>
 
     <android.support.design.widget.NavigationView
         android:id="@+id/navigationView"

--- a/app/src/main/res/layout/feed_recyclerview.xml
+++ b/app/src/main/res/layout/feed_recyclerview.xml
@@ -22,16 +22,4 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
     </android.support.v4.widget.SwipeRefreshLayout>
-
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="16dp"
-        android:src="@drawable/ic_pen"
-        app:elevation="5dp"
-        app:fabSize="normal"
-        app:layout_anchor="@id/swiperefresh"
-        app:layout_anchorGravity="bottom|right|end" />
 </merge>


### PR DESCRIPTION
Request signing:
According to docs, parameters should be sorted by name not value.

Toolbar autohide (#20):
FAB moved to activity, because `CoordinatorLayout`  can't manage non-direct children.