### PR TITLE
Fix crash when launching the app as unauthenticated user

### DIFF
--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/widgets/drawerheaderview/DrawerHeaderWidget.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/widgets/drawerheaderview/DrawerHeaderWidget.kt
@@ -53,7 +53,6 @@ class DrawerHeaderWidget : ConstraintLayout, DrawerHeaderView {
         super.onAttachedToWindow()
         presenter.subscribe(this)
         checkIsUserLoggedIn()
-        img_profile.loadImage(userManager.getUserCredentials()!!.avatarUrl)
     }
 
     override fun showErrorDialog(e: Throwable) = context.showExceptionDialog(e)


### PR DESCRIPTION
* checkIsUserLoggedIn() seems to already set the
  avatar thus it looks to be a leftover.