### PR TITLE
Fix lenny ¯\_(ツ)_/¯

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -93,7 +93,7 @@
         <item>( ͡° ͜ʖ ͡°)</item>
         <item>( ͡° ͜ʖ ͡°)ﾉ⌐■-■</item>
         <item>(⌐ ͡■ ͜ʖ ͡■)</item>
-        <item>¯\\_(ツ)_/¯</item>
+        <item>¯\\\_(ツ)_/¯</item>
         <item>(ꖘ⏏ꖘ)</item>
         <item>(╯°□°）╯︵ ┻━┻</item>
         <item>( ͡~ ͜ʖ ͡°)</item>


### PR DESCRIPTION
* Fix ¯\_(ツ)_/¯ lenny to see make it displaying correctly on whole website

Explain: `\\\_` <- 1st backslash escapes the 2nd backslash, and 3rd backslash escapes `_`