### PR TITLE
Use extension when adding into composite disposable.

### DIFF
--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/api/addlink/AddLinkRepository.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/api/addlink/AddLinkRepository.kt
@@ -17,8 +17,8 @@ import io.github.feelfreelinux.wykopmobilny.utils.preferences.SettingsPreference
 import io.reactivex.Single
 import retrofit2.Retrofit
 
-class AddLinkRepository(val retrofit: Retrofit, val userTokenRefresher: UserTokenRefresher, val owmContentFilter: OWMContentFilter) : AddlinkApi {
-    private val addlinkApi by lazy { retrofit.create(AddlinkRetrofitApi::class.java) }
+class AddLinkRepository(val retrofit: Retrofit, val userTokenRefresher: UserTokenRefresher, val owmContentFilter: OWMContentFilter) : AddLinkApi {
+    private val addlinkApi by lazy { retrofit.create(AddLinkRetrofitApi::class.java) }
 
     override fun getDraft(url: String): Single<NewLinkResponse> =
             addlinkApi.getDraft(url)

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/mapper/apiv2/LinkCommentMapper.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/mapper/apiv2/LinkCommentMapper.kt
@@ -8,7 +8,7 @@ import io.github.feelfreelinux.wykopmobilny.utils.toPrettyDate
 class LinkCommentMapper {
     companion object {
         fun map(value: LinkCommentResponse, owmContentFilter: OWMContentFilter) =
-            owmContentFilter.fiterLinkComment(
+            owmContentFilter.filterLinkComment(
                 LinkComment(
                     value.id, AuthorMapper.map(value.author), value.date.toPrettyDate(),
                     value.body, value.blocked,

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/fragments/entries/EntriesFragmentPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/fragments/entries/EntriesFragmentPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.entries.EntriesApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Entry
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 open class EntriesFragmentPresenter(
@@ -24,28 +25,26 @@ open class EntriesFragmentPresenter(
 
     override fun getVoters(entry: Entry) {
         view?.openVotersMenu()
-        compositeObservable.add(
-            entriesApi.getEntryVoters(entry.id)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showVoters(it)
-                }, {
-                    view?.showErrorDialog(it)
-                })
-        )
+        entriesApi.getEntryVoters(entry.id)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showVoters(it)
+            }, {
+                view?.showErrorDialog(it)
+            })
+            .intoComposite(compositeObservable)
     }
 
     private fun Single<Entry>.processEntrySingle(entry: Entry) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateEntry(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateEntry(entry)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateEntry(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateEntry(entry)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/addlink/fragments/confirmdetails/AddLinkDetailsFragmentPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/addlink/fragments/confirmdetails/AddLinkDetailsFragmentPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.addlink.fragments.confir
 import io.github.feelfreelinux.wykopmobilny.api.addlink.AddLinkApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class AddLinkDetailsFragmentPresenter(
     val schedulers: Schedulers,
@@ -11,18 +12,17 @@ class AddLinkDetailsFragmentPresenter(
 
     fun getImages(key: String) {
         view?.showImagesLoading(true)
-        compositeObservable.add(
-            addLinkApi.getImages(key)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showImages(it)
-                    view?.showImagesLoading(false)
-                }, {
-                    view?.showErrorDialog(it)
-                    view?.showImagesLoading(false)
-                })
-        )
+        addLinkApi.getImages(key)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showImages(it)
+                view?.showImagesLoading(false)
+            }, {
+                view?.showErrorDialog(it)
+                view?.showImagesLoading(false)
+            })
+            .intoComposite(compositeObservable)
     }
 
     fun publishLink(
@@ -35,13 +35,12 @@ class AddLinkDetailsFragmentPresenter(
         imageKey: String
     ) {
         view?.showLinkUploading(true)
-        compositeObservable.add(
-            addLinkApi.publishLink(key, title, description, tags, imageKey, sourceUrl, plus18)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.openLinkScreen(it)
-                }, { view?.showErrorDialog(it) })
-        )
+        addLinkApi.publishLink(key, title, description, tags, imageKey, sourceUrl, plus18)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.openLinkScreen(it)
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/addlink/fragments/urlinput/AddLinkUrlInputPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/addlink/fragments/urlinput/AddLinkUrlInputPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.addlink.fragments.urlinp
 import io.github.feelfreelinux.wykopmobilny.api.addlink.AddLinkApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class AddLinkUrlInputPresenter(
     val schedulers: Schedulers,
@@ -11,17 +12,16 @@ class AddLinkUrlInputPresenter(
 
     fun createDraft(url: String) {
         view?.showDuplicatesLoading(true)
-        compositeObservable.add(
-            addLinkApi.getDraft(url)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.setLinkDraft(it)
-                    view?.showDuplicatesLoading(false)
-                }, {
-                    view?.showErrorDialog(it)
-                    view?.showDuplicatesLoading(false)
-                })
-        )
+        addLinkApi.getDraft(url)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.setLinkDraft(it)
+                view?.showDuplicatesLoading(false)
+            }, {
+                view?.showErrorDialog(it)
+                view?.showDuplicatesLoading(false)
+            })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/blacklist/BlacklistPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/blacklist/BlacklistPresenter.kt
@@ -5,6 +5,7 @@ import io.github.feelfreelinux.wykopmobilny.api.scraper.ScraperApi
 import io.github.feelfreelinux.wykopmobilny.api.tag.TagApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class BlacklistPresenter(
     val schedulers: Schedulers,
@@ -14,55 +15,48 @@ class BlacklistPresenter(
 ) : BasePresenter<BlacklistView>() {
 
     fun importBlacklist() {
-        compositeObservable.add(
-            scraperApi.getBlacklist()
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.importBlacklist(it) }, { view?.showErrorDialog(it) })
-        )
+        scraperApi.getBlacklist()
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.importBlacklist(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun blockTag(tag: String) {
-        compositeObservable.add(
-            tagApi.block(tag)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.refreshResults() },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        tagApi.block(tag)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.refreshResults() },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun unblockTag(tag: String) {
-        compositeObservable.add(
-            tagApi.unblock(tag)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.refreshResults() },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        tagApi.unblock(tag)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.refreshResults() },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun blockUser(nick: String) {
-        compositeObservable.add(
-            profileApi.block(nick)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.refreshResults() }, { view?.showErrorDialog(it) })
-
-        )
+        profileApi.block(nick)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.refreshResults() }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun unblockUser(nick: String) {
-        compositeObservable.add(
-            profileApi.unblock(nick)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.refreshResults() }, { view?.showErrorDialog(it) })
-
-        )
+        profileApi.unblock(nick)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.refreshResults() }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/favorite/links/LinksFavoritePresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/favorite/links/LinksFavoritePresenter.kt
@@ -6,6 +6,7 @@ import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Link
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinkActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinksInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class LinksFavoritePresenter(
@@ -18,20 +19,19 @@ class LinksFavoritePresenter(
 
     fun loadData(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            linksApi.getObserved(page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        linksApi.getObserved(page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     override fun dig(link: Link) = linksInteractor.dig(link).processLinkSingle(link)
@@ -39,15 +39,14 @@ class LinksFavoritePresenter(
     override fun removeVote(link: Link) = linksInteractor.voteRemove(link).processLinkSingle(link)
 
     private fun Single<Link>.processLinkSingle(link: Link) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLink(link)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLink(link)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/input/entry/add/AddEntryPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/input/entry/add/AddEntryPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.WykopImageFile
 import io.github.feelfreelinux.wykopmobilny.api.entries.EntriesApi
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.ui.modules.input.InputPresenter
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class AddEntryPresenter(
     private val schedulers: Schedulers,
@@ -12,31 +13,29 @@ class AddEntryPresenter(
 
     override fun sendWithPhoto(photo: WykopImageFile, containsAdultContent: Boolean) {
         view?.showProgressBar = true
-        compositeObservable.add(
-            entriesApi.addEntry(view?.textBody!!, photo, containsAdultContent)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.openEntryActivity(it.id) },
-                    {
-                        view?.showProgressBar = false
-                        view?.showErrorDialog(it)
-                    })
-        )
+        entriesApi.addEntry(view?.textBody!!, photo, containsAdultContent)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.openEntryActivity(it.id) },
+                {
+                    view?.showProgressBar = false
+                    view?.showErrorDialog(it)
+                })
+            .intoComposite(compositeObservable)
     }
 
     override fun sendWithPhotoUrl(photo: String?, containsAdultContent: Boolean) {
         view?.showProgressBar = true
-        compositeObservable.add(
-            entriesApi.addEntry(view?.textBody!!, photo, containsAdultContent)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.openEntryActivity(it.id) },
-                    {
-                        view?.showProgressBar = false
-                        view?.showErrorDialog(it)
-                    })
-        )
+        entriesApi.addEntry(view?.textBody!!, photo, containsAdultContent)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.openEntryActivity(it.id) },
+                {
+                    view?.showProgressBar = false
+                    view?.showErrorDialog(it)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/input/entry/comment/EditEntryCommentPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/input/entry/comment/EditEntryCommentPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.WykopImageFile
 import io.github.feelfreelinux.wykopmobilny.api.entries.EntriesApi
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.ui.modules.input.InputPresenter
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class EditEntryCommentPresenter(
     private val schedulers: Schedulers,
@@ -12,17 +13,16 @@ class EditEntryCommentPresenter(
 
     private fun editComment() {
         view?.showProgressBar = true
-        compositeObservable.add(
-            entriesApi.editEntryComment(view?.textBody!!, view?.commentId!!)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.exitActivity() },
-                    {
-                        view?.showProgressBar = false
-                        view?.showErrorDialog(it)
-                    })
-        )
+        entriesApi.editEntryComment(view?.textBody!!, view?.commentId!!)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.exitActivity() },
+                {
+                    view?.showProgressBar = false
+                    view?.showErrorDialog(it)
+                })
+            .intoComposite(compositeObservable)
     }
 
     override fun sendWithPhoto(photo: WykopImageFile, containsAdultContent: Boolean) = editComment()

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/input/entry/edit/EditEntryPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/input/entry/edit/EditEntryPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.WykopImageFile
 import io.github.feelfreelinux.wykopmobilny.api.entries.EntriesApi
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.ui.modules.input.InputPresenter
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class EditEntryPresenter(
     private val schedulers: Schedulers,
@@ -12,17 +13,16 @@ class EditEntryPresenter(
 
     private fun editEntry() {
         view?.showProgressBar = true
-        compositeObservable.add(
-            entriesApi.editEntry(view?.textBody!!, view?.entryId!!)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.exitActivity() },
-                    {
-                        view?.showProgressBar = false
-                        view?.showErrorDialog(it)
-                    })
-        )
+        entriesApi.editEntry(view?.textBody!!, view?.entryId!!)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.exitActivity() },
+                {
+                    view?.showProgressBar = false
+                    view?.showErrorDialog(it)
+                })
+            .intoComposite(compositeObservable)
     }
 
     override fun sendWithPhoto(photo: WykopImageFile, containsAdultContent: Boolean) = editEntry()

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/input/link/edit/LinkCommentEditPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/input/link/edit/LinkCommentEditPresenter.kt
@@ -5,6 +5,7 @@ import io.github.feelfreelinux.wykopmobilny.api.links.LinksApi
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.ui.modules.input.BaseInputView
 import io.github.feelfreelinux.wykopmobilny.ui.modules.input.InputPresenter
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class LinkCommentEditPresenter(
     val schedulers: Schedulers,
@@ -15,17 +16,16 @@ class LinkCommentEditPresenter(
 
     private fun editLinkComment() {
         view?.showProgressBar = true
-        compositeObservable.add(
-            linksApi.commentEdit(view?.textBody!!, linkCommentId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.exitActivity() },
-                    {
-                        view?.showProgressBar = false
-                        view?.showErrorDialog(it)
-                    })
-        )
+        linksApi.commentEdit(view?.textBody!!, linkCommentId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.exitActivity() },
+                {
+                    view?.showProgressBar = false
+                    view?.showErrorDialog(it)
+                })
+            .intoComposite(compositeObservable)
     }
 
     override fun sendWithPhoto(photo: WykopImageFile, containsAdultContent: Boolean) = editLinkComment()

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/downvoters/DownvotersPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/downvoters/DownvotersPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.links.downvoters
 import io.github.feelfreelinux.wykopmobilny.api.links.LinksApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class DownvotersPresenter(
     val schedulers: Schedulers,
@@ -12,11 +13,10 @@ class DownvotersPresenter(
     var linkId = -1
 
     fun getDownvoters() {
-        compositeObservable.add(
-            linksApi.getDownvoters(linkId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showDownvoters(it) }, { view?.showErrorDialog(it) })
-        )
+        linksApi.getDownvoters(linkId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showDownvoters(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/hits/HitsPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/hits/HitsPresenter.kt
@@ -6,6 +6,7 @@ import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Link
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinkActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinksInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class HitsPresenter(
@@ -27,21 +28,20 @@ class HitsPresenter(
     var monthSelection = 0
 
     fun loadData() {
-        compositeObservable.add(
-            when (currentScreen) {
-                HITS_POPULAR -> hitsApi.popular()
-                HITS_DAY -> hitsApi.currentDay()
-                HITS_WEEK -> hitsApi.currentWeek()
-                HITS_MONTH -> hitsApi.byMonth(yearSelection, monthSelection)
-                else -> hitsApi.byYear(yearSelection)
-            }
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.addItems(it, true)
-                    view?.disableLoading()
-                }, { view?.showErrorDialog(it) })
-        )
+        when (currentScreen) {
+            HITS_POPULAR -> hitsApi.popular()
+            HITS_DAY -> hitsApi.currentDay()
+            HITS_WEEK -> hitsApi.currentWeek()
+            HITS_MONTH -> hitsApi.byMonth(yearSelection, monthSelection)
+            else -> hitsApi.byYear(yearSelection)
+        }
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.addItems(it, true)
+                view?.disableLoading()
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     override fun dig(link: Link) = linksInteractor.dig(link).processLinkSingle(link)
@@ -49,15 +49,13 @@ class HitsPresenter(
     override fun removeVote(link: Link) = linksInteractor.voteRemove(link).processLinkSingle(link)
 
     private fun Single<Link>.processLinkSingle(link: Link) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLink(link)
-                    })
-        )
+        this.subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLink(link)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/linkdetails/LinkDetailsPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/linkdetails/LinkDetailsPresenter.kt
@@ -10,6 +10,7 @@ import io.github.feelfreelinux.wykopmobilny.ui.fragments.link.LinkHeaderActionLi
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.link.LinkInteractor
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.linkcomments.LinkCommentActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.linkcomments.LinkCommentInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class LinkDetailsPresenter(
@@ -47,129 +48,121 @@ class LinkDetailsPresenter(
         linkCommentInteractor.removeComment(comment).processLinkCommentSingle(comment)
 
     fun loadComments(scrollCommentId: Int? = null) {
-        compositeObservable.add(
-            linksApi.getLinkComments(linkId, sortBy)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showLinkComments(it)
-                    scrollCommentId?.let {
-                        view?.scrollToComment(scrollCommentId)
-                    }
-                }, { view?.showErrorDialog(it) })
-        )
+        linksApi.getLinkComments(linkId, sortBy)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showLinkComments(it)
+                scrollCommentId?.let {
+                    view?.scrollToComment(scrollCommentId)
+                }
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun loadLinkAndComments(scrollCommentId: Int? = null) {
-        compositeObservable.add(
-            linksApi.getLink(linkId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.updateLink(it)
-                    loadComments(scrollCommentId)
-                }, { view?.showErrorDialog(it) })
-        )
+        linksApi.getLink(linkId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.updateLink(it)
+                loadComments(scrollCommentId)
+            }, {
+                view?.showErrorDialog(it)
+            })
+            .intoComposite(compositeObservable)
     }
 
     fun updateLink() {
-        compositeObservable.add(
-            linksApi.getLink(linkId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) }, { view?.showErrorDialog(it) })
-        )
+        linksApi.getLink(linkId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun sendReply(body: String, typedInputStream: WykopImageFile, containsAdultContent: Boolean) {
         val replyCommentId = view!!.getReplyCommentId()
         if (replyCommentId != -1) {
-            compositeObservable.add(
-                linksApi.commentAdd(body, containsAdultContent, typedInputStream, linkId, replyCommentId)
-                    .subscribeOn(schedulers.backgroundThread())
-                    .observeOn(schedulers.mainThread())
-                    .subscribe({
-                        view?.resetInputbarState()
-                        view?.hideInputToolbar()
-                        loadComments(it.id)
-                    }, {
-                        view?.showErrorDialog(it)
-                        view?.hideInputbarProgress()
-                    })
-            )
+            linksApi.commentAdd(body, containsAdultContent, typedInputStream, linkId, replyCommentId)
+                .subscribeOn(schedulers.backgroundThread())
+                .observeOn(schedulers.mainThread())
+                .subscribe({
+                    view?.resetInputbarState()
+                    view?.hideInputToolbar()
+                    loadComments(it.id)
+                }, {
+                    view?.showErrorDialog(it)
+                    view?.hideInputbarProgress()
+                })
+                .intoComposite(compositeObservable)
         } else {
-            compositeObservable.add(
-                linksApi.commentAdd(body, containsAdultContent, typedInputStream, linkId)
-                    .subscribeOn(schedulers.backgroundThread())
-                    .observeOn(schedulers.mainThread())
-                    .subscribe({
-                        view?.resetInputbarState()
-                        view?.hideInputToolbar()
-                        loadComments(it.id)
-                    }, {
-                        view?.showErrorDialog(it)
-                        view?.hideInputbarProgress()
-                    })
-            )
+            linksApi.commentAdd(body, containsAdultContent, typedInputStream, linkId)
+                .subscribeOn(schedulers.backgroundThread())
+                .observeOn(schedulers.mainThread())
+                .subscribe({
+                    view?.resetInputbarState()
+                    view?.hideInputToolbar()
+                    loadComments(it.id)
+                }, {
+                    view?.showErrorDialog(it)
+                    view?.hideInputbarProgress()
+                })
+                .intoComposite(compositeObservable)
         }
     }
 
     fun sendReply(body: String, embed: String?, containsAdultContent: Boolean) {
         val replyCommentId = view!!.getReplyCommentId()
         if (replyCommentId != -1) {
-            compositeObservable.add(
-                linksApi.commentAdd(body, embed, containsAdultContent, linkId, replyCommentId)
-                    .subscribeOn(schedulers.backgroundThread())
-                    .observeOn(schedulers.mainThread())
-                    .subscribe({
-                        view?.resetInputbarState()
-                        view?.hideInputToolbar()
-                        loadComments(it.id)
-                    }, {
-                        view?.showErrorDialog(it)
-                        view?.hideInputbarProgress()
-                    })
-            )
+            linksApi.commentAdd(body, embed, containsAdultContent, linkId, replyCommentId)
+                .subscribeOn(schedulers.backgroundThread())
+                .observeOn(schedulers.mainThread())
+                .subscribe({
+                    view?.resetInputbarState()
+                    view?.hideInputToolbar()
+                    loadComments(it.id)
+                }, {
+                    view?.showErrorDialog(it)
+                    view?.hideInputbarProgress()
+                })
+                .intoComposite(compositeObservable)
         } else {
-            compositeObservable.add(
-                linksApi.commentAdd(body, embed, containsAdultContent, linkId)
-                    .subscribeOn(schedulers.backgroundThread())
-                    .observeOn(schedulers.mainThread())
-                    .subscribe({
-                        view?.resetInputbarState()
-                        view?.hideInputToolbar()
-                        loadComments(it.id)
-                    }, {
-                        view?.showErrorDialog(it)
-                        view?.hideInputbarProgress()
-                    })
-            )
+            linksApi.commentAdd(body, embed, containsAdultContent, linkId)
+                .subscribeOn(schedulers.backgroundThread())
+                .observeOn(schedulers.mainThread())
+                .subscribe({
+                    view?.resetInputbarState()
+                    view?.hideInputToolbar()
+                    loadComments(it.id)
+                }, {
+                    view?.showErrorDialog(it)
+                    view?.hideInputbarProgress()
+                })
+                .intoComposite(compositeObservable)
         }
     }
 
     private fun Single<LinkComment>.processLinkCommentSingle(link: LinkComment) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLinkComment(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLinkComment(link)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLinkComment(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLinkComment(link)
+                })
+            .intoComposite(compositeObservable)
     }
 
     private fun Single<Link>.processLinkSingle(link: Link) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLink(link)
-                    })
-        )
+        this.subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLink(link)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/promoted/PromotedPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/promoted/PromotedPresenter.kt
@@ -6,6 +6,7 @@ import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Link
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinkActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinksInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class PromotedPresenter(
@@ -18,20 +19,19 @@ class PromotedPresenter(
 
     fun getPromotedLinks(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            linksApi.getPromoted(page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        linksApi.getPromoted(page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     override fun dig(link: Link) = linksInteractor.dig(link).processLinkSingle(link)
@@ -39,15 +39,13 @@ class PromotedPresenter(
     override fun removeVote(link: Link) = linksInteractor.voteRemove(link).processLinkSingle(link)
 
     private fun Single<Link>.processLinkSingle(link: Link) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLink(link)
-                    })
-        )
+        this.subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLink(link)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/related/RelatedPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/related/RelatedPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.links.related
 import io.github.feelfreelinux.wykopmobilny.api.links.LinksApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class RelatedPresenter(
     val schedulers: Schedulers,
@@ -12,11 +13,10 @@ class RelatedPresenter(
     var linkId = -1
 
     fun getRelated() {
-        compositeObservable.add(
-            linksApi.getRelated(linkId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showRelated(it) }, { view?.showErrorDialog(it) })
-        )
+        linksApi.getRelated(linkId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showRelated(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/upvoters/UpvotersPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/upvoters/UpvotersPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.links.upvoters
 import io.github.feelfreelinux.wykopmobilny.api.links.LinksApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class UpvotersPresenter(
     val schedulers: Schedulers,
@@ -12,11 +13,10 @@ class UpvotersPresenter(
     var linkId = -1
 
     fun getUpvoters() {
-        compositeObservable.add(
-            linksApi.getUpvoters(linkId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showUpvoters(it) }, { view?.showErrorDialog(it) })
-        )
+        linksApi.getUpvoters(linkId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showUpvoters(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/loginscreen/LoginScreenPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/loginscreen/LoginScreenPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.scraper.ScraperApi
 import io.github.feelfreelinux.wykopmobilny.api.user.LoginApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.github.feelfreelinux.wykopmobilny.utils.usermanager.LoginCredentials
 import io.github.feelfreelinux.wykopmobilny.utils.usermanager.UserManagerApi
 import io.reactivex.Single
@@ -19,16 +20,15 @@ class LoginScreenPresenter(
         extractToken(url)?.apply {
             userManager.loginUser(this)
 
-            compositeObservable.add(
-                userApi.getUserSessionToken()
-                    .subscribeOn(schedulers.backgroundThread())
-                    .observeOn(schedulers.mainThread())
-                    .flatMap { it ->
-                        userManager.saveCredentials(it)
-                        Single.just(it)
-                    }
-                    .subscribe({ view?.goBackToSplashScreen() }, { view?.showErrorDialog(it) })
-            )
+            userApi.getUserSessionToken()
+                .subscribeOn(schedulers.backgroundThread())
+                .observeOn(schedulers.mainThread())
+                .flatMap { it ->
+                    userManager.saveCredentials(it)
+                    Single.just(it)
+                }
+                .subscribe({ view?.goBackToSplashScreen() }, { view?.showErrorDialog(it) })
+                .intoComposite(compositeObservable)
         }
     }
 
@@ -58,11 +58,10 @@ class LoginScreenPresenter(
     }
 
     fun importBlacklist() {
-        compositeObservable.add(
-            scraperApi.getBlacklist()
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.importBlacklist(it) }, { view?.showErrorDialog(it) })
-        )
+        scraperApi.getBlacklist()
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.importBlacklist(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mainnavigation/MainNavigationPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mainnavigation/MainNavigationPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.notifications.NotificationsApi
 import io.github.feelfreelinux.wykopmobilny.api.scraper.ScraperApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.github.feelfreelinux.wykopmobilny.utils.usermanager.UserManagerApi
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
@@ -37,25 +38,22 @@ class MainNavigationPresenter(
     fun checkNotifications(shouldForce: Boolean) {
         if (lastCheckMillis.plus(300000L) < (System.currentTimeMillis()) || lastCheckMillis == 0L || shouldForce) {
             lastCheckMillis = System.currentTimeMillis()
-            compositeObservable.add(
-                notificationsApi.getNotificationCount().subscribeOn(schedulers.backgroundThread())
-                    .observeOn(schedulers.mainThread())
-                    .subscribe({ view?.showNotificationsCount(it.count) }, { })
-            )
-            compositeObservable.add(
-                notificationsApi.getHashTagNotificationCount().subscribeOn(schedulers.backgroundThread())
-                    .observeOn(schedulers.mainThread())
-                    .subscribe({ view?.showHashNotificationsCount(it.count) }, { })
-            )
+            notificationsApi.getNotificationCount().subscribeOn(schedulers.backgroundThread())
+                .observeOn(schedulers.mainThread())
+                .subscribe({ view?.showNotificationsCount(it.count) }, { })
+                .intoComposite(compositeObservable)
+            notificationsApi.getHashTagNotificationCount().subscribeOn(schedulers.backgroundThread())
+                .observeOn(schedulers.mainThread())
+                .subscribe({ view?.showHashNotificationsCount(it.count) }, { })
+                .intoComposite(compositeObservable)
         }
     }
 
     fun importBlacklist() {
-        compositeObservable.add(
-            scraperApi.getBlacklist()
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.importBlacklist(it) }, { view?.showErrorDialog(it) })
-        )
+        scraperApi.getBlacklist()
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.importBlacklist(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/entry/EntryDetailPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/entry/EntryDetailPresenter.kt
@@ -10,6 +10,7 @@ import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntriesInteract
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntryActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entrycomments.EntryCommentActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entrycomments.EntryCommentInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class EntryDetailPresenter(
@@ -38,16 +39,15 @@ class EntryDetailPresenter(
 
     override fun getVoters(entry: Entry) {
         view?.openVotersMenu()
-        compositeObservable.add(
-            entriesApi.getEntryVoters(entry.id)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showVoters(it)
-                }, {
-                    view?.showErrorDialog(it)
-                })
-        )
+        entriesApi.getEntryVoters(entry.id)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showVoters(it)
+            }, {
+                view?.showErrorDialog(it)
+            })
+            .intoComposite(compositeObservable)
     }
 
     override fun voteComment(comment: EntryComment) =
@@ -61,90 +61,87 @@ class EntryDetailPresenter(
 
     override fun getVoters(comment: EntryComment) {
         view?.openVotersMenu()
-        compositeObservable.add(
-            entriesApi.getEntryCommentVoters(comment.id)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showVoters(it)
-                }, {
-                    view?.showErrorDialog(it)
-                })
-        )
+        entriesApi.getEntryCommentVoters(comment.id)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showVoters(it)
+            }, {
+                view?.showErrorDialog(it)
+            })
+            .intoComposite(compositeObservable)
     }
 
     fun loadData() {
         view?.hideInputToolbar()
-        compositeObservable.add(
-            entriesApi.getEntry(entryId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.showEntry(it) },
-                    { view?.showErrorDialog(it) }
-                ))
-
+        entriesApi.getEntry(entryId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.showEntry(it) },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun addComment(body: String, photo: WykopImageFile, containsAdultContent: Boolean) {
-        compositeObservable.add(
-            entriesApi.addEntryComment(body, entryId, photo, containsAdultContent)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        view?.hideInputbarProgress()
-                        view?.resetInputbarState()
-                        loadData() // Refresh view
-                    },
-                    {
-                        view?.hideInputbarProgress()
-                        view?.showErrorDialog(it)
-                    }
-                ))
+        entriesApi.addEntryComment(body, entryId, photo, containsAdultContent)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    view?.hideInputbarProgress()
+                    view?.resetInputbarState()
+                    loadData() // Refresh view
+                },
+                {
+                    view?.hideInputbarProgress()
+                    view?.showErrorDialog(it)
+                }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun addComment(body: String, photo: String?, containsAdultContent: Boolean) {
-        compositeObservable.add(
-            entriesApi.addEntryComment(body, entryId, photo, containsAdultContent)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        view?.hideInputbarProgress()
-                        view?.resetInputbarState()
-                        loadData() // Refresh view
-                    },
-                    {
-                        view?.hideInputbarProgress()
-                        view?.showErrorDialog(it)
-                    }
-                ))
+        entriesApi.addEntryComment(body, entryId, photo, containsAdultContent)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    view?.hideInputbarProgress()
+                    view?.resetInputbarState()
+                    loadData() // Refresh view
+                },
+                {
+                    view?.hideInputbarProgress()
+                    view?.showErrorDialog(it)
+                }
+            )
+            .intoComposite(compositeObservable)
     }
 
     private fun Single<Entry>.processEntrySingle(entry: Entry) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateEntry(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateEntry(entry)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateEntry(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateEntry(entry)
+                })
+            .intoComposite(compositeObservable)
+
     }
 
     private fun Single<EntryComment>.processEntryCommentSingle(comment: EntryComment) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateComment(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateComment(comment)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateComment(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateComment(comment)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/feed/hot/HotPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/feed/hot/HotPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.entries.EntriesApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Entry
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 
 class HotPresenter(
@@ -24,7 +25,6 @@ class HotPresenter(
         }
         val failure: (Throwable) -> Unit = { view?.showErrorDialog(it) }
 
-        compositeObservable.add(
             when (period) {
                 "24", "12", "6" -> {
                     entriesApi.getHot(page, period).subscribeOn(schedulers.backgroundThread())
@@ -41,6 +41,6 @@ class HotPresenter(
                         .observeOn(schedulers.mainThread())
                         .subscribe(success, failure)
             }
-        )
+                .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mywykop/index/MyWykopEntryLinkPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mywykop/index/MyWykopEntryLinkPresenter.kt
@@ -12,6 +12,7 @@ import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntryActionList
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entrylink.EntryLinkFragmentView
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinkActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinksInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class MyWykopEntryLinkPresenter(
@@ -27,56 +28,53 @@ class MyWykopEntryLinkPresenter(
 
     fun loadIndex(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            myWykopApi.getIndex(page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        myWykopApi.getIndex(page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun loadTags(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            myWykopApi.byTags(page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        myWykopApi.byTags(page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun loadUsers(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            myWykopApi.byUsers(page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        myWykopApi.byUsers(page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     override fun voteEntry(entry: Entry) =
@@ -96,16 +94,15 @@ class MyWykopEntryLinkPresenter(
 
     override fun getVoters(entry: Entry) {
         view?.openVotersMenu()
-        compositeObservable.add(
-            entriesApi.getEntryVoters(entry.id)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showVoters(it)
-                }, {
-                    view?.showErrorDialog(it)
-                })
-        )
+        entriesApi.getEntryVoters(entry.id)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showVoters(it)
+            }, {
+                view?.showErrorDialog(it)
+            })
+            .intoComposite(compositeObservable)
     }
 
     override fun dig(link: Link) =
@@ -115,28 +112,26 @@ class MyWykopEntryLinkPresenter(
         linksInteractor.voteRemove(link).processLinkSingle(link)
 
     private fun Single<Entry>.processEntrySingle(entry: Entry) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateEntry(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateEntry(entry)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateEntry(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateEntry(entry)
+                })
+            .intoComposite(compositeObservable)
     }
 
     private fun Single<Link>.processLinkSingle(link: Link) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLink(link)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLink(link)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mywykop/observedtags/MyWykopObservedTagsPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mywykop/observedtags/MyWykopObservedTagsPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.mywykop.observedtags
 import io.github.feelfreelinux.wykopmobilny.api.tag.TagApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class MyWykopObservedTagsPresenter(
     val schedulers: Schedulers,
@@ -10,11 +11,10 @@ class MyWykopObservedTagsPresenter(
 ) : BasePresenter<MyWykopObservedTagsView>() {
 
     fun loadTags() {
-        compositeObservable.add(
-            tagsApi.getObservedTags()
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showTags(it) }, { view?.showErrorDialog(it) })
-        )
+        tagsApi.getObservedTags()
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showTags(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/notificationslist/hashtags/HashTagsNotificationsListPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/notificationslist/hashtags/HashTagsNotificationsListPresenter.kt
@@ -6,83 +6,79 @@ import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Notification
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.NotificationHeader
 import io.github.feelfreelinux.wykopmobilny.ui.modules.notificationslist.NotificationsListView
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class HashTagsNotificationsListPresenter(
     val schedulers: Schedulers,
-    val notificationsApi: NotificationsApi
+    private val notificationsApi: NotificationsApi
 ) : BasePresenter<NotificationsListView>() {
 
     var page = 1
 
     fun loadData(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            notificationsApi.getHashTagNotifications(page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    if (it.isNotEmpty()) {
-                        page++
-                        view?.addNotifications(it, shouldRefresh)
-                    } else view?.disableLoading()
-                }, { view?.showErrorDialog(it) })
-        )
+        notificationsApi.getHashTagNotifications(page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                if (it.isNotEmpty()) {
+                    page++
+                    view?.addNotifications(it, shouldRefresh)
+                } else view?.disableLoading()
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun readNotifications() {
-        compositeObservable.add(
-            notificationsApi.readHashTagNotifications()
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showReadToast() }, { view?.showErrorDialog(it) })
-        )
+        notificationsApi.readHashTagNotifications()
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showReadToast() }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun loadAllNotifications(shouldRefresh: Boolean) {
-        compositeObservable.add(
-            notificationsApi.getHashTagNotificationCount()
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    if (it.count > 325) {
-                        view?.showTooManyNotifications()
-                    } else {
-                        fetchAllPages(shouldRefresh)
-                    }
-                }, { view?.showErrorDialog(it) })
-        )
-
+        notificationsApi.getHashTagNotificationCount()
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                if (it.count > 325) {
+                    view?.showTooManyNotifications()
+                } else {
+                    fetchAllPages(shouldRefresh)
+                }
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     private fun fetchAllPages(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
         val allData = arrayListOf<Notification>()
         var dataEmpty = false
-        compositeObservable.add(
-            Single.defer { notificationsApi.getHashTagNotifications(page) }
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .repeatUntil { dataEmpty }
-                .subscribe({
-                    val data = it.filter { it.new }.toMutableList()
+        Single.defer { notificationsApi.getHashTagNotifications(page) }
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .repeatUntil { dataEmpty }
+            .subscribe({
+                val data = it.filter { it.new }.toMutableList()
 
-                    if (data.isNotEmpty()) {
-                        allData.addAll(data)
-                        page++
-                    } else {
-                        dataEmpty = true
+                if (data.isNotEmpty()) {
+                    allData.addAll(data)
+                    page++
+                } else {
+                    dataEmpty = true
 
-                        val sortedData = arrayListOf<Notification>()
+                    val sortedData = arrayListOf<Notification>()
 
-                        for (notification in allData.map { it.tag }.toHashSet().toList()) {
-                            sortedData.add(NotificationHeader(notification, allData.count { item -> item.tag == notification }))
-                            sortedData.addAll(allData.filter { it.tag == notification })
-                        }
-                        view?.addNotifications(sortedData, true)
-                        view?.disableLoading()
+                    for (notification in allData.map { it.tag }.toHashSet().toList()) {
+                        sortedData.add(NotificationHeader(notification, allData.count { item -> item.tag == notification }))
+                        sortedData.addAll(allData.filter { it.tag == notification })
                     }
-                }, { view?.showErrorDialog(it) })
-        )
+                    view?.addNotifications(sortedData, true)
+                    view?.disableLoading()
+                }
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/notificationslist/notification/NotificationsListPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/notificationslist/notification/NotificationsListPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.notifications.NotificationsApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.ui.modules.notificationslist.NotificationsListView
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class NotificationsListPresenter(
     val schedulers: Schedulers,
@@ -14,25 +15,23 @@ class NotificationsListPresenter(
 
     fun loadData(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            notificationsApi.getNotifications(page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    if (it.isNotEmpty()) {
-                        page++
-                        view?.addNotifications(it, shouldRefresh)
-                    } else view?.disableLoading()
-                }, { view?.showErrorDialog(it) })
-        )
+        notificationsApi.getNotifications(page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                if (it.isNotEmpty()) {
+                    page++
+                    view?.addNotifications(it, shouldRefresh)
+                } else view?.disableLoading()
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun readNotifications() {
-        compositeObservable.add(
-            notificationsApi.readNotifications()
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showReadToast() }, { view?.showErrorDialog(it) })
-        )
+        notificationsApi.readNotifications()
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showReadToast() }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/pm/conversation/ConversationPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/pm/conversation/ConversationPresenter.kt
@@ -4,6 +4,7 @@ import io.github.feelfreelinux.wykopmobilny.api.WykopImageFile
 import io.github.feelfreelinux.wykopmobilny.api.pm.PMApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class ConversationPresenter(
     val schedulers: Schedulers,
@@ -13,50 +14,47 @@ class ConversationPresenter(
     lateinit var user: String
 
     fun loadConversation() {
-        compositeObservable.add(
-            pmApi.getConversation(user)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.showConversation(it) },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        pmApi.getConversation(user)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.showConversation(it) },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun sendMessage(body: String, photo: String?, containsAdultContent: Boolean) {
-        compositeObservable.add(
-            pmApi.sendMessage(body, user, photo, containsAdultContent)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        view?.hideInputbarProgress()
-                        view?.resetInputbarState()
-                        loadConversation()
-                    },
-                    {
-                        view?.hideInputbarProgress()
-                        view?.showErrorDialog(it)
-                    })
-        )
+        pmApi.sendMessage(body, user, photo, containsAdultContent)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    view?.hideInputbarProgress()
+                    view?.resetInputbarState()
+                    loadConversation()
+                },
+                {
+                    view?.hideInputbarProgress()
+                    view?.showErrorDialog(it)
+                })
+            .intoComposite(compositeObservable)
     }
 
     fun sendMessage(body: String, photo: WykopImageFile, containsAdultContent: Boolean) {
-        compositeObservable.add(
-            pmApi.sendMessage(body, user, containsAdultContent, photo)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        view?.hideInputbarProgress()
-                        view?.resetInputbarState()
-                        loadConversation()
-                    },
-                    {
-                        view?.hideInputbarProgress()
-                        view?.showErrorDialog(it)
-                    })
-        )
+        pmApi.sendMessage(body, user, containsAdultContent, photo)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    view?.hideInputbarProgress()
+                    view?.resetInputbarState()
+                    loadConversation()
+                },
+                {
+                    view?.hideInputbarProgress()
+                    view?.showErrorDialog(it)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/pm/conversationslist/ConversationsListPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/pm/conversationslist/ConversationsListPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.pm.conversationslist
 import io.github.feelfreelinux.wykopmobilny.api.pm.PMApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class ConversationsListPresenter(
     private val schedulers: Schedulers,
@@ -10,11 +11,10 @@ class ConversationsListPresenter(
 ) : BasePresenter<ConversationsListView>() {
 
     fun loadConversations() {
-        compositeObservable.add(
-            pmApi.getConversations()
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showConversations(it) }, { view?.showErrorDialog(it) })
-        )
+        pmApi.getConversations()
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showConversations(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/ProfilePresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/ProfilePresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.profile
 import io.github.feelfreelinux.wykopmobilny.api.profile.ProfileApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class ProfilePresenter(
     val schedulers: Schedulers,
@@ -12,60 +13,50 @@ class ProfilePresenter(
     var userName = "a__s"
 
     fun loadData() {
-        compositeObservable.add(
-            profileApi.getIndex(userName)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showProfile(it) }, { view?.showErrorDialog(it) })
-        )
+        profileApi.getIndex(userName)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showProfile(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun markObserved() {
-        compositeObservable.add(
-            profileApi.observe(userName)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showButtons(it) }, { view?.showErrorDialog(it) })
-
-        )
+        profileApi.observe(userName)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showButtons(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun markUnobserved() {
-        compositeObservable.add(
-            profileApi.unobserve(userName)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showButtons(it) }, { view?.showErrorDialog(it) })
-
-        )
+        profileApi.unobserve(userName)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showButtons(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun markBlocked() {
-        compositeObservable.add(
-            profileApi.block(userName)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showButtons(it) }, { view?.showErrorDialog(it) })
-
-        )
+        profileApi.block(userName)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showButtons(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun markUnblocked() {
-        compositeObservable.add(
-            profileApi.unblock(userName)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showButtons(it) }, { view?.showErrorDialog(it) })
-
-        )
+        profileApi.unblock(userName)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showButtons(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun getBadges() {
-        compositeObservable.add(
-            profileApi.getBadges(userName, 0)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.showBadges(it) }, { view?.showErrorDialog(it) })
-        )
+        profileApi.getBadges(userName, 0)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.showBadges(it) }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/actions/ActionsFragmentPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/actions/ActionsFragmentPresenter.kt
@@ -10,6 +10,7 @@ import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntriesInteract
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntryActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinkActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinksInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class ActionsFragmentPresenter(
@@ -23,15 +24,14 @@ class ActionsFragmentPresenter(
     lateinit var username: String
 
     fun getActions() {
-        compositeObservable.add(
-            profileApi.getActions(username)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.addItems(it, true)
-                    view?.disableLoading()
-                }, { view?.showErrorDialog(it) })
-        )
+        profileApi.getActions(username)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.addItems(it, true)
+                view?.disableLoading()
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     override fun voteEntry(entry: Entry) =
@@ -51,16 +51,15 @@ class ActionsFragmentPresenter(
 
     override fun getVoters(entry: Entry) {
         view?.openVotersMenu()
-        compositeObservable.add(
-            entriesApi.getEntryVoters(entry.id)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showVoters(it)
-                }, {
-                    view?.showErrorDialog(it)
-                })
-        )
+        entriesApi.getEntryVoters(entry.id)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showVoters(it)
+            }, {
+                view?.showErrorDialog(it)
+            })
+            .intoComposite(compositeObservable)
     }
 
     override fun dig(link: Link) =
@@ -70,28 +69,26 @@ class ActionsFragmentPresenter(
         linksInteractor.voteRemove(link).processLinkSingle(link)
 
     private fun Single<Entry>.processEntrySingle(entry: Entry) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateEntry(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateEntry(entry)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateEntry(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateEntry(entry)
+                })
+            .intoComposite(compositeObservable)
     }
 
     private fun Single<Link>.processLinkSingle(link: Link) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLink(link)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLink(link)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/badge/BadgePresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/badge/BadgePresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.profile.badge
 import io.github.feelfreelinux.wykopmobilny.api.profile.ProfileApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class BadgePresenter(
     val schedulers: Schedulers,
@@ -14,19 +15,18 @@ class BadgePresenter(
 
     fun loadData(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            profileApi.getBadges(username, page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addDataToAdapter(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        profileApi.getBadges(username, page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addDataToAdapter(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/links/added/ProfileLinksPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/links/added/ProfileLinksPresenter.kt
@@ -6,6 +6,7 @@ import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Link
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinkActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinksInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class ProfileLinksPresenter(
@@ -19,74 +20,70 @@ class ProfileLinksPresenter(
 
     fun loadAdded(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            profileApi.getAdded(username, page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        profileApi.getAdded(username, page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun loadBurried(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            profileApi.getBuried(username, page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        profileApi.getBuried(username, page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun loadDigged(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            profileApi.getDigged(username, page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        profileApi.getDigged(username, page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun loadPublished(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            profileApi.getPublished(username, page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addItems(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        profileApi.getPublished(username, page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addItems(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     override fun dig(link: Link) {
@@ -98,15 +95,14 @@ class ProfileLinksPresenter(
     }
 
     private fun Single<Link>.processLinkSingle(link: Link) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLink(link)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLink(link)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/links/related/ProfileRelatedPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/profile/links/related/ProfileRelatedPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.profile.links.related
 import io.github.feelfreelinux.wykopmobilny.api.profile.ProfileApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class ProfileRelatedPresenter(
     val schedulers: Schedulers,
@@ -14,19 +15,18 @@ class ProfileRelatedPresenter(
 
     fun loadData(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            profileApi.getRelated(username, page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        if (it.isNotEmpty()) {
-                            page++
-                            view?.addDataToAdapter(it, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        profileApi.getRelated(username, page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    if (it.isNotEmpty()) {
+                        page++
+                        view?.addDataToAdapter(it, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/search/entry/EntrySearchPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/search/entry/EntrySearchPresenter.kt
@@ -7,6 +7,7 @@ import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Entry
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntriesInteractor
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntryActionListener
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class EntrySearchPresenter(
@@ -20,21 +21,20 @@ class EntrySearchPresenter(
 
     fun searchEntries(q: String, shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            searchApi.searchEntries(page, q)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showSearchEmptyView = (page == 1 && it.isEmpty())
-                    if (it.isNotEmpty()) {
-                        page++
-                        view?.addItems(it, shouldRefresh)
-                    } else {
-                        view?.addItems(it, (page == 1))
-                        view?.disableLoading()
-                    }
-                }, { view?.showErrorDialog(it) })
-        )
+        searchApi.searchEntries(page, q)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showSearchEmptyView = (page == 1 && it.isEmpty())
+                if (it.isNotEmpty()) {
+                    page++
+                    view?.addItems(it, shouldRefresh)
+                } else {
+                    view?.addItems(it, (page == 1))
+                    view?.disableLoading()
+                }
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     override fun voteEntry(entry: Entry) =
@@ -54,28 +54,26 @@ class EntrySearchPresenter(
 
     override fun getVoters(entry: Entry) {
         view?.openVotersMenu()
-        compositeObservable.add(
-            entriesApi.getEntryVoters(entry.id)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showVoters(it)
-                }, {
-                    view?.showErrorDialog(it)
-                })
-        )
+        entriesApi.getEntryVoters(entry.id)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showVoters(it)
+            }, {
+                view?.showErrorDialog(it)
+            })
+            .intoComposite(compositeObservable)
     }
 
     private fun Single<Entry>.processEntrySingle(entry: Entry) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateEntry(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateEntry(entry)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateEntry(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateEntry(entry)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/search/links/LinkSearchPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/search/links/LinkSearchPresenter.kt
@@ -6,6 +6,7 @@ import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Link
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinkActionListener
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.links.LinksInteractor
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class LinkSearchPresenter(
@@ -18,21 +19,20 @@ class LinkSearchPresenter(
 
     fun searchLinks(q: String, shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            searchApi.searchLinks(page, q)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showSearchEmptyView = (page == 1 && it.isEmpty())
-                    if (it.isNotEmpty()) {
-                        page++
-                        view?.addItems(it, shouldRefresh)
-                    } else {
-                        view?.addItems(it, (page == 1))
-                        view?.disableLoading()
-                    }
-                }, { view?.showErrorDialog(it) })
-        )
+        searchApi.searchLinks(page, q)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showSearchEmptyView = (page == 1 && it.isEmpty())
+                if (it.isNotEmpty()) {
+                    page++
+                    view?.addItems(it, shouldRefresh)
+                } else {
+                    view?.addItems(it, (page == 1))
+                    view?.disableLoading()
+                }
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     override fun dig(link: Link) = linksInteractor.dig(link).processLinkSingle(link)
@@ -40,15 +40,14 @@ class LinkSearchPresenter(
     override fun removeVote(link: Link) = linksInteractor.voteRemove(link).processLinkSingle(link)
 
     private fun Single<Link>.processLinkSingle(link: Link) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateLink(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateLink(link)
-                    })
-        )
+        this
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateLink(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateLink(link)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/search/users/UsersSearchPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/search/users/UsersSearchPresenter.kt
@@ -3,21 +3,21 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.search.users
 import io.github.feelfreelinux.wykopmobilny.api.search.SearchApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class UsersSearchPresenter(
     val schedulers: Schedulers,
-    val searchApi: SearchApi
+    private val searchApi: SearchApi
 ) : BasePresenter<UsersSearchView>() {
 
     fun searchProfiles(q: String) {
-        compositeObservable.add(
-            searchApi.searchProfiles(q)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.showUsers(it) },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        searchApi.searchProfiles(q)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.showUsers(it) },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/tag/TagActivityPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/tag/TagActivityPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.modules.tag
 import io.github.feelfreelinux.wykopmobilny.api.tag.TagApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 
 class TagActivityPresenter(
     val schedulers: Schedulers,
@@ -12,50 +13,46 @@ class TagActivityPresenter(
     lateinit var tag: String
 
     fun blockTag() {
-        compositeObservable.add(
-            tagApi.block(tag)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.setObserveState(it) },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        tagApi.block(tag)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.setObserveState(it) },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun unblockTag() {
-        compositeObservable.add(
-            tagApi.unblock(tag)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.setObserveState(it) },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        tagApi.unblock(tag)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.setObserveState(it) },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun observeTag() {
-        compositeObservable.add(
-            tagApi.observe(tag)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.setObserveState(it) },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        tagApi.observe(tag)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.setObserveState(it) },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     fun unobserveTag() {
-        compositeObservable.add(
-            tagApi.unobserve(tag)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    { view?.setObserveState(it) },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        tagApi.unobserve(tag)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                { view?.setObserveState(it) },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/tag/entries/TagEntriesPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/tag/entries/TagEntriesPresenter.kt
@@ -7,6 +7,7 @@ import io.github.feelfreelinux.wykopmobilny.base.Schedulers
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Entry
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntriesInteractor
 import io.github.feelfreelinux.wykopmobilny.ui.fragments.entries.EntryActionListener
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.reactivex.Single
 
 class TagEntriesPresenter(
@@ -21,21 +22,20 @@ class TagEntriesPresenter(
 
     fun loadData(shouldRefresh: Boolean) {
         if (shouldRefresh) page = 1
-        compositeObservable.add(
-            tagApi.getTagEntries(tag, page)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe(
-                    {
-                        view?.setParentMeta(it.meta)
-                        if (it.entries.isNotEmpty()) {
-                            page++
-                            view?.addItems(it.entries, shouldRefresh)
-                        } else view?.disableLoading()
-                    },
-                    { view?.showErrorDialog(it) }
-                )
-        )
+        tagApi.getTagEntries(tag, page)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe(
+                {
+                    view?.setParentMeta(it.meta)
+                    if (it.entries.isNotEmpty()) {
+                        page++
+                        view?.addItems(it.entries, shouldRefresh)
+                    } else view?.disableLoading()
+                },
+                { view?.showErrorDialog(it) }
+            )
+            .intoComposite(compositeObservable)
     }
 
     override fun voteEntry(entry: Entry) =
@@ -55,28 +55,25 @@ class TagEntriesPresenter(
 
     override fun getVoters(entry: Entry) {
         view?.openVotersMenu()
-        compositeObservable.add(
-            entriesApi.getEntryVoters(entry.id)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.showVoters(it)
-                }, {
-                    view?.showErrorDialog(it)
-                })
-        )
+        entriesApi.getEntryVoters(entry.id)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.showVoters(it)
+            }, {
+                view?.showErrorDialog(it)
+            })
+            .intoComposite(compositeObservable)
     }
 
     private fun Single<Entry>.processEntrySingle(entry: Entry) {
-        compositeObservable.add(
-            this
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({ view?.updateEntry(it) },
-                    {
-                        view?.showErrorDialog(it)
-                        view?.updateEntry(entry)
-                    })
-        )
+        this.subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({ view?.updateEntry(it) },
+                {
+                    view?.showErrorDialog(it)
+                    view?.updateEntry(entry)
+                })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/widgets/link/related/RelatedWidgetPresenter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/widgets/link/related/RelatedWidgetPresenter.kt
@@ -3,6 +3,7 @@ package io.github.feelfreelinux.wykopmobilny.ui.widgets.link.related
 import io.github.feelfreelinux.wykopmobilny.api.links.LinksApi
 import io.github.feelfreelinux.wykopmobilny.base.BasePresenter
 import io.github.feelfreelinux.wykopmobilny.base.Schedulers
+import io.github.feelfreelinux.wykopmobilny.utils.intoComposite
 import io.github.feelfreelinux.wykopmobilny.utils.wykop_link_handler.WykopLinkHandlerApi
 
 class RelatedWidgetPresenter(
@@ -16,26 +17,24 @@ class RelatedWidgetPresenter(
     fun handleLink(url: String) = linkHandlerApi.handleUrl(url)
 
     fun voteUp() {
-        compositeObservable.add(
-            linksApi.relatedVoteUp(relatedId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.setVoteCount(it.voteCount)
-                    view?.markVoted()
-                }, { view?.showErrorDialog(it) })
-        )
+        linksApi.relatedVoteUp(relatedId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.setVoteCount(it.voteCount)
+                view?.markVoted()
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 
     fun voteDown() {
-        compositeObservable.add(
-            linksApi.relatedVoteDown(relatedId)
-                .subscribeOn(schedulers.backgroundThread())
-                .observeOn(schedulers.mainThread())
-                .subscribe({
-                    view?.setVoteCount(it.voteCount)
-                    view?.markUnvoted()
-                }, { view?.showErrorDialog(it) })
-        )
+        linksApi.relatedVoteDown(relatedId)
+            .subscribeOn(schedulers.backgroundThread())
+            .observeOn(schedulers.mainThread())
+            .subscribe({
+                view?.setVoteCount(it.voteCount)
+                view?.markUnvoted()
+            }, { view?.showErrorDialog(it) })
+            .intoComposite(compositeObservable)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/utils/RxExtensions.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/utils/RxExtensions.kt
@@ -1,0 +1,8 @@
+package io.github.feelfreelinux.wykopmobilny.utils
+
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
+
+fun Disposable.intoComposite(compositeDisposable: CompositeDisposable) {
+    compositeDisposable.add(this)
+}


### PR DESCRIPTION
Just a simple QoL suggestion. This PR basically utilizes extension and changes this: 

```
        compositeObservable.add(
            profileApi.block(nick)
                .subscribeOn(schedulers.backgroundThread())
                .observeOn(schedulers.mainThread())
                .subscribe({ view?.refreshResults() }, { view?.showErrorDialog(it) })
        )
```

into this

```
        profileApi.block(nick)
            .subscribeOn(schedulers.backgroundThread())
            .observeOn(schedulers.mainThread())
            .subscribe({ view?.refreshResults() }, { view?.showErrorDialog(it) })
            .intoComposite(compositeObservable)
```

for better readability.