### PR TITLE
Remove unused abstraction.

### DIFF
--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/mapper/apiv2/LinkCommentMapper.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/mapper/apiv2/LinkCommentMapper.kt
@@ -8,7 +8,7 @@ import io.github.feelfreelinux.wykopmobilny.utils.toPrettyDate
 class LinkCommentMapper {
     companion object {
         fun map(value: LinkCommentResponse, owmContentFilter: OWMContentFilter) =
-            owmContentFilter.fiterLinkComment(
+            owmContentFilter.filterLinkComment(
                 LinkComment(
                     value.id, AuthorMapper.map(value.author), value.date.toPrettyDate(),
                     value.body, value.blocked,

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/EntryAdapter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/EntryAdapter.kt
@@ -92,11 +92,6 @@ class EntryAdapter @Inject constructor(
         }
     }
 
-    override fun onViewRecycled(holder: androidx.recyclerview.widget.RecyclerView.ViewHolder) {
-        (holder as? RecyclableViewHolder)?.cleanRecycled()
-        super.onViewRecycled(holder)
-    }
-
     fun updateEntry(entry: Entry) {
         this.entry = entry
         notifyItemChanged(0)

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/LinkAdapter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/LinkAdapter.kt
@@ -5,7 +5,6 @@ import io.github.feelfreelinux.wykopmobilny.base.adapter.AdvancedProgressAdapter
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Link
 import io.github.feelfreelinux.wykopmobilny.ui.adapters.viewholders.BlockedViewHolder
 import io.github.feelfreelinux.wykopmobilny.ui.adapters.viewholders.LinkViewHolder
-import io.github.feelfreelinux.wykopmobilny.ui.adapters.viewholders.RecyclableViewHolder
 import io.github.feelfreelinux.wykopmobilny.ui.adapters.viewholders.SimpleLinkViewHolder
 import io.github.feelfreelinux.wykopmobilny.utils.preferences.SettingsPreferencesApi
 import javax.inject.Inject
@@ -30,10 +29,4 @@ class LinkAdapter @Inject constructor(val settingsPreferencesApi: SettingsPrefer
         if (holder is SimpleLinkViewHolder) holder.bindView(item)
         else (holder as? LinkViewHolder)?.bindView(item)
     }
-
-    override fun onViewRecycled(holder: androidx.recyclerview.widget.RecyclerView.ViewHolder) {
-        (holder as? RecyclableViewHolder)?.cleanRecycled()
-        super.onViewRecycled(holder)
-    }
-
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/LinkDetailsAdapter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/LinkDetailsAdapter.kt
@@ -101,11 +101,6 @@ class LinkDetailsAdapter @Inject constructor(
         }
     }
 
-    override fun onViewRecycled(holder: androidx.recyclerview.widget.RecyclerView.ViewHolder) {
-        (holder as? RecyclableViewHolder)?.cleanRecycled()
-        super.onViewRecycled(holder)
-    }
-
     fun updateLinkComment(comment: LinkComment) {
         val position = link!!.comments.indexOf(comment)
         link!!.comments[position] = comment

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/PMMessageAdapter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/PMMessageAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import io.github.feelfreelinux.wykopmobilny.R
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.PMMessage
 import io.github.feelfreelinux.wykopmobilny.ui.adapters.viewholders.PMMessageViewHolder
-import io.github.feelfreelinux.wykopmobilny.ui.adapters.viewholders.RecyclableViewHolder
 import io.github.feelfreelinux.wykopmobilny.ui.modules.NewNavigatorApi
 import io.github.feelfreelinux.wykopmobilny.utils.preferences.SettingsPreferencesApi
 import io.github.feelfreelinux.wykopmobilny.utils.wykop_link_handler.WykopLinkHandlerApi
@@ -32,7 +31,7 @@ class PMMessageAdapter @Inject constructor(
         holder.bindView(messages[position])
 
     override fun onViewRecycled(holder: PMMessageViewHolder) {
-        (holder as? RecyclableViewHolder)?.cleanRecycled()
+        (holder as? PMMessageViewHolder)?.cleanRecycled()
         super.onViewRecycled(holder)
     }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/ProfileRelatedAdapter.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/ProfileRelatedAdapter.kt
@@ -5,7 +5,6 @@ import android.view.ViewGroup
 import io.github.feelfreelinux.wykopmobilny.R
 import io.github.feelfreelinux.wykopmobilny.base.adapter.EndlessProgressAdapter
 import io.github.feelfreelinux.wykopmobilny.models.dataclass.Related
-import io.github.feelfreelinux.wykopmobilny.ui.adapters.viewholders.RecyclableViewHolder
 import io.github.feelfreelinux.wykopmobilny.ui.adapters.viewholders.RelatedViewHolder
 import io.github.feelfreelinux.wykopmobilny.ui.widgets.link.related.RelatedWidgetPresenterFactory
 import io.github.feelfreelinux.wykopmobilny.utils.usermanager.UserManagerApi
@@ -27,9 +26,4 @@ class ProfileRelatedAdapter @Inject constructor(
             userManagerApi,
             relatedWidgetPresenterFactory.create()
         )
-
-    override fun onViewRecycled(holder: androidx.recyclerview.widget.RecyclerView.ViewHolder) {
-        (holder as? RecyclableViewHolder)?.cleanRecycled()
-        super.onViewRecycled(holder)
-    }
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/BaseLinkCommentViewHolder.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/BaseLinkCommentViewHolder.kt
@@ -90,9 +90,6 @@ abstract class BaseLinkCommentViewHolder(
     abstract var shareButton: TextView
     open var collapsedCommentsTextView: TextView? = null
 
-    override fun cleanRecycled() {
-    }
-
     open fun bindView(linkComment: LinkComment, isAuthorComment: Boolean, commentId: Int = -1) {
         setupBody(linkComment)
         setupButtons(linkComment)

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/EntryCommentViewHolder.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/EntryCommentViewHolder.kt
@@ -230,9 +230,6 @@ class EntryCommentViewHolder(
         dialog.show()
     }
 
-    override fun cleanRecycled() {
-    }
-
     private fun handleClick(comment: EntryComment) {
         if (enableClickListener) {
             navigatorApi.openEntryDetailsActivity(comment.entryId, isEmbedViewResized)

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/EntryViewHolder.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/EntryViewHolder.kt
@@ -270,9 +270,6 @@ class EntryViewHolder(
         }
     }
 
-    override fun cleanRecycled() {
-    }
-
     fun inflateEmbed() {
         embedView = entryImageViewStub.inflate() as WykopEmbedView
     }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/LinkHeaderViewHolder.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/LinkHeaderViewHolder.kt
@@ -54,9 +54,6 @@ class LinkHeaderViewHolder(
         }
     }
 
-    override fun cleanRecycled() {
-    }
-
     fun bindView(link: Link) {
         when (link.userVote) {
             "dig" -> showDigged(link)
@@ -111,7 +108,7 @@ class LinkHeaderViewHolder(
     private fun setupBody(link: Link) {
         titleTextView.text = link.title.removeHtml()
         image.isVisible = link.preview != null
-        link.preview?.let { image.loadImage(link.preview!!.stripImageCompression()) }
+        link.preview?.let { image.loadImage(link.preview.stripImageCompression()) }
         description.text = link.description.removeHtml()
         relatedCountTextView.text = link.relatedCount.toString()
         relatedCountTextView.setOnClickListener {

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/LinkViewHolder.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/LinkViewHolder.kt
@@ -85,10 +85,6 @@ class LinkViewHolder(
         }
     }
 
-    override fun cleanRecycled() {
-
-    }
-
     fun bindView(link: Link) {
         setupBody(link)
         setupButtons(link)

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/PMMessageViewHolder.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/PMMessageViewHolder.kt
@@ -79,7 +79,7 @@ class PMMessageViewHolder(
         view.notificationItem.layoutParams = cardViewParams
     }
 
-    override fun cleanRecycled() {
+    fun cleanRecycled() {
         view.apply {
             date.text = null
             body.text = null

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/RecyclableViewHolder.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/RecyclableViewHolder.kt
@@ -8,8 +8,4 @@ abstract class RecyclableViewHolder(view: View) : androidx.recyclerview.widget.R
         const val SEPARATOR_SMALL = "SEP_SMALL"
         const val SEPARATOR_NORMAL = "SEP_NORMAL"
     }
-
-    open var separatorType = SEPARATOR_SMALL
-
-    abstract fun cleanRecycled()
 }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/SimpleLinkViewHolder.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/adapters/viewholders/SimpleLinkViewHolder.kt
@@ -143,8 +143,4 @@ class SimpleLinkViewHolder(
         simple_image.alpha = alpha
         simple_title.alpha = alpha
     }
-
-    override fun cleanRecycled() {
-        //Do nothing
-    }
 }


### PR DESCRIPTION
Stumbled upon `cleanRecycled()` method which is actually only used in one place.