### PR TITLE
Do not show Input Toolbar in entry if OP blacklisted user

### DIFF
--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/dataclass/Entry.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/dataclass/Entry.kt
@@ -16,7 +16,8 @@ class Entry(
     val violationUrl: String,
     var isNsfw: Boolean = false,
     var isBlocked: Boolean = false,
-    var collapsed: Boolean = true
+    var collapsed: Boolean = true,
+    val isCommentingPossible: Boolean
 ) {
     override fun equals(other: Any?): Boolean {
         return if (other !is Entry) false

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/mapper/apiv2/EntryMapper.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/mapper/apiv2/EntryMapper.kt
@@ -26,7 +26,9 @@ class EntryMapper {
                     value.app,
                     value.violationUrl ?: "",
                     value.body?.toLowerCase()?.contains("#nsfw") ?: false,
-                    value.blocked
+                    value.blocked,
+                    true,
+                    value.isCommentingPossible
                 )
             )
     }

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/pojo/apiv2/models/EntryResponse.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/pojo/apiv2/models/EntryResponse.kt
@@ -19,5 +19,6 @@ class EntryResponse(
     @JsonProperty("survey") val survey: SurveyResponse?,
     @JsonProperty("user_vote") val userVote: Int,
     @JsonProperty("violation_url") val violationUrl: String?,
-    @JsonProperty("app") val app: String?
+    @JsonProperty("app") val app: String?,
+    @JsonProperty("can_comment") val isCommentingPossible: Boolean
 )

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/entry/EntryDetailActivity.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/mikroblog/entry/EntryDetailActivity.kt
@@ -155,6 +155,7 @@ class EntryActivity : BaseActivity(), EntryDetailView, InputToolbarListener, Swi
         adapter.entry = entry
         entry.comments.forEach { it.entryId = entry.id }
         inputToolbar.setDefaultAddressant(entry.author.nick)
+        inputToolbar.setIfIsCommentingPossible(entry.isCommentingPossible)
         inputToolbar.show()
         loadingView?.isVisible = false
         swiperefresh?.isRefreshing = false

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/widgets/InputToolbar.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/widgets/InputToolbar.kt
@@ -55,6 +55,7 @@ class InputToolbar @JvmOverloads constructor(
     var defaultText = ""
     var showToolbar = false
     var inputToolbarListener: InputToolbarListener? = null
+    var isCommentingPossible = false
 
     private val usersSuggestionAdapter by lazy { UsersSuggestionsAdapter(context, suggestApi) }
     private val hashTagsSuggestionAdapter by lazy { HashTagsSuggestionsAdapter(context, suggestApi) }
@@ -241,9 +242,14 @@ class InputToolbar @JvmOverloads constructor(
         imm.showSoftInput(body, InputMethodManager.SHOW_IMPLICIT)
     }
 
+    fun setIfIsCommentingPossible(value: Boolean) {
+        isCommentingPossible = value
+    }
+
     fun show() {
-        // Only show if user's logged in
-        isVisible = userManager.isUserAuthorized()
+        // Only show if user's logged in and has permissions to do it
+        // If OP blacklisted user, then user cannot respond to his entries
+        isVisible = userManager.isUserAuthorized() && isCommentingPossible
     }
 
     override fun onRestoreInstanceState(state: Parcelable?) {


### PR DESCRIPTION
If user opens an entry, which author blacklisted a user, then Input Toolbar doesn't show up.
Example:
![screenshot_wykop_mobilny_20181018-200645](https://user-images.githubusercontent.com/11798442/47174746-c81c4200-d311-11e8-9003-4b6fc981817d.png)

Known bug: response button shows up and when clicked, opens useless keyboard