### PR TITLE
[BUGFIX] Invalid scroll position when hiding all comments by default

### DIFF
--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/mapper/apiv2/LinkCommentMapper.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/models/mapper/apiv2/LinkCommentMapper.kt
@@ -8,7 +8,7 @@ import io.github.feelfreelinux.wykopmobilny.utils.toPrettyDate
 class LinkCommentMapper {
     companion object {
         fun map(value: LinkCommentResponse, owmContentFilter: OWMContentFilter) =
-            owmContentFilter.fiterLinkComment(
+            owmContentFilter.filterLinkComment(
                 LinkComment(
                     value.id, AuthorMapper.map(value.author), value.date.toPrettyDate(),
                     value.body, value.blocked,

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/linkdetails/LinkDetailsActivity.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/linkdetails/LinkDetailsActivity.kt
@@ -217,11 +217,8 @@ class LinkDetailsActivity : BaseActivity(), LinkDetailsView, androidx.swiperefre
     }
 
     override fun scrollToComment(id: Int) {
-        adapter.link!!.comments.forEachIndexed({ index, comment ->
-            if (comment.id == id) {
-                recyclerView?.scrollToPosition(index + 1)
-            }
-        })
+        val index = adapter.link!!.comments.indexOfFirst { it.id == id }
+        recyclerView?.scrollToPosition(index + 1)
     }
 
     override fun updateLink(link: Link) {

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/linkdetails/LinkDetailsActivity.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/links/linkdetails/LinkDetailsActivity.kt
@@ -212,8 +212,34 @@ class LinkDetailsActivity : BaseActivity(), LinkDetailsView, androidx.swiperefre
         adapter.notifyDataSetChanged()
         inputToolbar.show()
         if (linkCommentId != -1 && adapter.link != null) {
-            scrollToComment(linkCommentId)
+            if (settingsApi.hideLinkCommentsByDefault) {
+                expandAndScrollToComment(linkCommentId)
+            } else {
+                scrollToComment(linkCommentId)
+            }
         }
+    }
+
+    private fun expandAndScrollToComment(linkCommentId: Int) {
+        adapter.link?.comments?.let { allComments ->
+            val parentId = allComments.find { it.id == linkCommentId }?.parentId
+            allComments.forEach {
+                if (it.parentId == parentId) {
+                    it.isCollapsed = false
+                    it.isParentCollapsed = false
+                }
+            }
+        }
+        adapter.notifyDataSetChanged()
+
+        val comments = adapter.link!!.comments
+        var index = 0
+        for (i in 0 until comments.size) {
+            if (!comments[i].isParentCollapsed) index++
+            if (comments[i].id ==  linkCommentId) break
+        }
+
+        recyclerView?.scrollToPosition(index + 1)
     }
 
     override fun scrollToComment(id: Int) {


### PR DESCRIPTION
When the user settings option 'Hide all link's comments by default' is enabled clicking notification sends user to given link activity but scrolls to a random place.

This PR solves the issues by expanding relevant parent and calculating scroll index properly after.