### PR TITLE
Fix NPE if youtube url is not a video url.

### DIFF
--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/embedview/YTPlayer.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/embedview/YTPlayer.kt
@@ -50,6 +50,10 @@ object YouTubeUrlParser {
     fun getVideoUrl(@NonNull videoId: String): String {
         return "http://youtu.be/$videoId"
     }
+
+    fun isVideoUrl(url: String): Boolean {
+        return reg.toRegex().find(url) != null
+    }
 }
 
 object StatusBarUtil {

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/utils/wykop_link_handler/WykopLinkHandler.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/utils/wykop_link_handler/WykopLinkHandler.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import io.github.feelfreelinux.wykopmobilny.ui.modules.NewNavigator
 import io.github.feelfreelinux.wykopmobilny.ui.modules.NewNavigatorApi
 import io.github.feelfreelinux.wykopmobilny.ui.modules.embedview.EmbedViewActivity
+import io.github.feelfreelinux.wykopmobilny.ui.modules.embedview.YouTubeUrlParser
 import io.github.feelfreelinux.wykopmobilny.ui.modules.links.linkdetails.LinkDetailsActivity
 import io.github.feelfreelinux.wykopmobilny.ui.modules.mikroblog.entry.EntryActivity
 import io.github.feelfreelinux.wykopmobilny.ui.modules.pm.conversation.ConversationActivity
@@ -65,7 +66,11 @@ class WykopLinkHandler(val context: Activity, private val navigatorApi: NewNavig
                         else -> null
                     }
                 }
-                "youtu", "youtube", "gfycat", "streamable", "coub" -> EmbedViewActivity.createIntent(context, url)
+                "gfycat", "streamable", "coub" -> EmbedViewActivity.createIntent(context, url)
+                "youtu", "youtube" -> {
+                    if (YouTubeUrlParser.isVideoUrl(url)) EmbedViewActivity.createIntent(context, url)
+                    else null
+                }
                 else -> null
             }
         }


### PR DESCRIPTION
App crashes if YT url is a link to the channel. Before extracting ID and opening player, app must check if given URL is a video url. 

Crash stack trace:

```(java)
com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: java.lang.NullPointerException: Video ID must not be null
        at io.github.feelfreelinux.wykopmobilny.ui.modules.embedview.YTPlayer.initialize(YTPlayer.kt:147)
        at io.github.feelfreelinux.wykopmobilny.ui.modules.embedview.YTPlayer.onCreate(YTPlayer.kt:119)
````

[Video with test](https://streamable.com/49ngx)
