### PR TITLE
Include YouTube timestamp param in built in YouTube player.

### DIFF
--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/embedview/YoutubeActivity.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/embedview/YoutubeActivity.kt
@@ -25,6 +25,9 @@ class YoutubeActivity {
         fun createIntent(context: Context, url: String): Intent {
             val intent = Intent(context, YTPlayer::class.java)
             intent.putExtra(YTPlayer.EXTRA_VIDEO_ID, YouTubeUrlParser.getVideoId(url))
+            YouTubeUrlParser.getTimestamp(url)?.let { t ->
+                intent.putExtra(YTPlayer.EXTRA_TIMESTAMP, t)
+            }
             return intent
         }
 

--- a/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/utils/Extensions.kt
+++ b/app/src/main/kotlin/io/github/feelfreelinux/wykopmobilny/utils/Extensions.kt
@@ -2,11 +2,9 @@ package io.github.feelfreelinux.wykopmobilny.utils
 
 import android.app.Activity
 import android.content.ContentResolver
-import android.content.Context
 import android.content.ContextWrapper
 import android.graphics.drawable.Drawable
 import android.net.Uri
-import android.os.Build
 import android.provider.OpenableColumns
 import android.text.SpannableStringBuilder
 import android.view.View
@@ -27,6 +25,7 @@ import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalTime
 import org.threeten.bp.Period
 import org.threeten.bp.format.DateTimeFormatter
+import org.threeten.bp.format.DateTimeParseException
 import java.util.Locale
 
 var View.isVisible: Boolean
@@ -137,6 +136,32 @@ fun Uri.queryFileName(contentResolver: ContentResolver): String {
         }
     }
     return result
+}
+
+/**
+ * Parse YouTube timestamp from string to milliseconds value.
+ *
+ * Original value comes from 't' parameter from youtube url and is given in seconds. YouTube player needs this
+ * value in milliseconds.
+ *
+ * Parameter 't' can be in following formats:
+ * '3' we can assume that this values is in seconds
+ * '3m', '5m30s', '1h30m30s' needs conversion using ISO 8601.
+ *
+ * @return time in milliseconds, null if value cannot be converted.
+ *
+ */
+fun String.youtubeTimestampToMsOrNull(): Int? {
+    val timestamp = this.toLongOrNull()
+    if (timestamp != null) {
+        return Duration.ofSeconds(timestamp).toMillis().toInt()
+    }
+
+    return try {
+        Duration.parse("PT${this}").toMillis().toInt()
+    } catch (e: DateTimeParseException) {
+        null
+    }
 }
 
 class KotlinGlideRequestListener(val failedListener: (GlideException?) -> Unit, val successListener: () -> Unit) : RequestListener<Drawable> {

--- a/app/src/test/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/embedview/YouTubeUrlParserTest.kt
+++ b/app/src/test/kotlin/io/github/feelfreelinux/wykopmobilny/ui/modules/embedview/YouTubeUrlParserTest.kt
@@ -1,0 +1,38 @@
+package io.github.feelfreelinux.wykopmobilny.ui.modules.embedview
+
+import org.junit.Test
+
+import org.junit.Assert.*
+
+class YouTubeUrlParserTest {
+
+    @Test
+    fun `test getVideoId`() {
+        val url1 = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        val url2 = "https://www.youtube.com/watch?v=TeST"
+
+        assertEquals("dQw4w9WgXcQ", YouTubeUrlParser.getVideoId(url1))
+        assertNull(YouTubeUrlParser.getVideoId(url2))
+    }
+
+    @Test
+    fun getTimestamp() {
+        val url1 = "https://youtu.be/dQw4w9WgXcQ?t=68"
+        val url2 = "https://youtu.be/dQw4w9WgXcQ?t=3m"
+
+        assertEquals("68", YouTubeUrlParser.getTimestamp(url1))
+        assertEquals("3m", YouTubeUrlParser.getTimestamp(url2))
+    }
+
+    @Test
+    fun `test isVideoUrl return false when url is user profile`() {
+        val url = "https://www.youtube.com/user/GoogleMobile"
+        assertFalse(YouTubeUrlParser.isVideoUrl(url))
+    }
+
+    @Test
+    fun `test isVideoUrl should return true`() {
+        val url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        assertTrue(YouTubeUrlParser.isVideoUrl(url))
+    }
+}

--- a/app/src/test/kotlin/io/github/feelfreelinux/wykopmobilny/utils/ExtensionsTest.kt
+++ b/app/src/test/kotlin/io/github/feelfreelinux/wykopmobilny/utils/ExtensionsTest.kt
@@ -1,0 +1,26 @@
+package io.github.feelfreelinux.wykopmobilny.utils
+
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ExtensionsTest {
+
+    @Test
+    fun `test youtubeTimestampToMsOrNull`() {
+        val format1 = "5" // 5 seconds = 5.000ms
+        val format2 = "3h3m30s" // 11.010.000ms
+        val format3 = "1m10s" // 70.000ms
+        val format4 = "25s" // 25.000ms
+        val format5 = "malformed_time"
+
+        assertEquals(5_000, format1.youtubeTimestampToMsOrNull())
+        assertEquals(11_010_000, format2.youtubeTimestampToMsOrNull())
+        assertEquals(70_000, format3.youtubeTimestampToMsOrNull())
+        assertEquals(25_000, format4.youtubeTimestampToMsOrNull())
+        assertNull(format5.youtubeTimestampToMsOrNull())
+    }
+}


### PR DESCRIPTION
Built in YT player doesn't handle timestamp parameter from YT links. I found this a very useful feature and I think is worth to be implemented. 

Video with self testing: https://streamable.com/utylt

First link (Jimmy Kimmel video) has param t=33, second video is t=3s, third video doesn't have t.